### PR TITLE
fix typo in mma optimizer

### DIFF
--- a/models/mmaOptimize.py
+++ b/models/mmaOptimize.py
@@ -54,7 +54,7 @@ def optimize(mesh, optimizationParams, ft, \
         xold2 = xold1.copy();
         xold1 = xval.copy();
         rho = xmma.copy().flatten()
-        mma.registerMMAIter(rho, xval.copy(), xold1.copy())
+        mma.registerMMAIter(rho, xval.copy(), xold2.copy())
 
         mmaTime += time.perf_counter() - tmr;
 


### PR DESCRIPTION
There seems to be a typo in the code, causing slightly worse behavior of the mma solver.

https://github.com/UW-ERSL/AuTO/blob/f88b6e988c7eeae548e727eecec34b5462eb1c33/models/mmaOptimize.py#L57

In the code above, `xold1.copy()` should be `xold2.copy()` because the value of `xold1` has already been accidentally updated.